### PR TITLE
Crashes were identified due to direct access to Player->m_pActiveItem…

### DIFF
--- a/spread/Spread.cpp
+++ b/spread/Spread.cpp
@@ -224,7 +224,7 @@ float CSpread::GetSpread(CBaseEntity *pEntity, Vector &vecSrc, Vector &vecDirSho
                 {
                     if (this->m_Weapons->string[0u] != '\0')
                     {
-                        if (Player->m_pActiveItem->m_iId >= WEAPON_P228 && Player->m_pActiveItem->m_iId <= WEAPON_P90)
+                        if (Player->m_pActiveItem && Player->m_pActiveItem->m_iId >= WEAPON_P228 && Player->m_pActiveItem->m_iId <= WEAPON_P90)
                         {
                             if (DebugMode)
                             {
@@ -248,7 +248,7 @@ float CSpread::GetSpread(CBaseEntity *pEntity, Vector &vecSrc, Vector &vecDirSho
                 }
 
                 // Do not remove spred if player is not aimming his weapons like AWP, SCOUT or other
-                if (!Player->m_bResumeZoom)
+                if (!Player->m_bResumeZoom && Player->m_pActiveItem)
                 {
                     if (Player->m_pActiveItem->m_iId == WEAPON_SCOUT || Player->m_pActiveItem->m_iId == WEAPON_SG550 || Player->m_pActiveItem->m_iId == WEAPON_AWP || Player->m_pActiveItem->m_iId == WEAPON_G3SG1)
                     {


### PR DESCRIPTION
###  Fix: Crash when accessing null `m_pActiveItem` in Spread.cpp

#### Issue

Crashes were identified due to direct access to `Player->m_pActiveItem->m_iId` without prior null pointer validation.
In certain scenarios, `m_pActiveItem` can be `nullptr`, leading to invalid memory access.

#### Root Cause

Missing null checks before accessing `m_iId` in two code sections:

* Blocked weapons check (~line 227)
* Zoom weapons logic (~line 253)

#### Solution

Added validation to ensure `m_pActiveItem` is not null before accessing its members.

#### Changes

**1. Blocked Weapons Check**

```cpp
// Before
if (Player->m_pActiveItem->m_iId >= WEAPON_P228 && ...)

// After
if (Player->m_pActiveItem && Player->m_pActiveItem->m_iId >= WEAPON_P228 && ...)
```

**2. Zoom Weapons**

```cpp
// Before
if (!Player->m_bResumeZoom)
{
    if (Player->m_pActiveItem->m_iId == WEAPON_SCOUT || ...)
}

// After
if (!Player->m_bResumeZoom && Player->m_pActiveItem)
{
    if (Player->m_pActiveItem->m_iId == WEAPON_SCOUT || ...)
}
```

#### Impact

* Prevents crashes caused by null pointer dereference
* Improves overall server stability
* No functional logic changes beyond safety checks

#### Testing

* Verified scenarios where player has no active weapon
* No regressions observed in weapon or zoom logic

---

✅ Safe and isolated fix
