### PR TITLE
Fix validation issues causing crashes and conflicts with other modules

### DIFF
--- a/spread/Spread.cpp
+++ b/spread/Spread.cpp
@@ -127,20 +127,151 @@ void CSpread::ServerActivate()
 
 float CSpread::GetSpread(CBaseEntity *pEntity, Vector &vecSrc, Vector &vecDirShooting, float vecSpread, float flDistance, int iPenetration, int iBulletType, int iDamage, float flRangeModifier, entvars_t *pevAttacker, bool bPistol, int shared_rand)
 {
-    if (this->m_Active)
+    // guard the entire function with a plugin-active check first,
+    // before touching pEntity at all.
+    if (!this->m_Active || this->m_Active->value <= 0.0f)
     {
-        if (this->m_Active->value > 0.0f)
+        return vecSpread;
+    }
+
+    // pEntity null check BEFORE the static_cast.
+    // FireBullets3 can be called by non-player entities (func_tank, NPCs, etc.).
+    // The original code did static_cast<CBasePlayer*>(pEntity) with no validation,
+    // trusting that a non-null pointer is always a valid player — it is not.
+    if (!pEntity || !pEntity->pev)
+    {
+        return vecSpread;
+    }
+
+    // validate the edict is alive and not freed before dereferencing.
+    // edict()->free == 1 means the slot was recycled; pvPrivateData may be stale.
+    edict_t *pEdict = pEntity->edict();
+    if (!pEdict || pEdict->free)
+    {
+        return vecSpread;
+    }
+
+    // confirm the entity is actually a player before casting.
+    // Without this, any non-player entity that fires bullets (bots with custom
+    // code, func_tank, rezombie custom entities, etc.) causes the cast to
+    // reinterpret an arbitrary CBaseEntity layout as CBasePlayer, leading to
+    // out-of-bounds field reads -> SIGSEGV.
+    int entIdx = ENTINDEX(pEdict);
+    if (entIdx < 1 || entIdx > gpGlobals->maxClients)
+    {
+        // Not a player slot — pass through unchanged.
+        return vecSpread;
+    }
+
+    // Safe to cast now: slot is in the player range and edict is not free.
+    auto Player = static_cast<CBasePlayer *>(pEntity);
+
+    bool DebugMode = (this->m_Debug && this->m_Debug->value > 0.0f);
+
+    // If player is not on ground, block spread fix
+    if (this->m_GroundCheck)
+    {
+        if (this->m_GroundCheck->value > 0.0f)
         {
-            auto Player = static_cast<CBasePlayer*>(pEntity);
-
-            if (Player)
+            if (DebugMode)
             {
-                bool DebugMode = (this->m_Debug && this->m_Debug->value > 0.0f);
+                this->ClientPrint
+                (
+                    Player->edict(),
+                    E_PRINT::CHAT,
+                    "[%s] Ground Check: %2.2f (OnGround: %s) (Pass: %s)",
+                    Plugin_info.logtag,
+                    this->m_GroundCheck->value,
+                    (Player->pev->flags & FL_ONGROUND) ? "Yes" : "No",
+                    (Player->pev->flags & FL_ONGROUND) ? "Yes" : "No"
+                );
+            }
 
-                // If player is not on ground, block spread fix
-                if (this->m_GroundCheck)
+            if (!(Player->pev->flags & FL_ONGROUND))
+            {
+                return vecSpread;
+            }
+        }
+    }
+
+    // If player is moving: Block if player speed is greater than: (weapon-max-speed / max-speed-cvar-value)
+    if (this->m_MaxSpeed)
+    {
+        if (this->m_MaxSpeed->value > 0.0f)
+        {
+            if (Player->pev->maxspeed > 0.0f)
+            {
+                if (DebugMode)
                 {
-                    if (this->m_GroundCheck->value > 0.0f)
+                    this->ClientPrint
+                    (
+                        Player->edict(),
+                        E_PRINT::CHAT,
+                        "[%s] Max Speed Divisor: %2.2f (Player Velocity: %2.2f) (MaxSpeed: %2.2f) (Pass: %s)",
+                        Plugin_info.logtag,
+                        this->m_MaxSpeed->value,
+                        Player->pev->velocity.Length2D(),
+                        Player->pev->maxspeed,
+                        (Player->pev->velocity.Length2D() <= (Player->pev->maxspeed / this->m_MaxSpeed->value)) ? "Yes" : "No"
+                    );
+                }
+
+                if (Player->pev->velocity.Length2D() > (Player->pev->maxspeed / this->m_MaxSpeed->value))
+                {
+                    return vecSpread;
+                }
+            }
+        }
+    }
+
+    // If player has fired: Do not remove spread if player is shoting a lot
+    if (this->m_MaxPunchAngle)
+    {
+        if (this->m_MaxPunchAngle->value >= 0.0f)
+        {
+            if (DebugMode)
+            {
+                this->ClientPrint
+                (
+                    Player->edict(),
+                    E_PRINT::CHAT,
+                    "[%s] Max Punch Angle: %2.2f (Player Punch Angle: %2.2f) (Pass: %s)",
+                    Plugin_info.logtag,
+                    this->m_MaxPunchAngle->value,
+                    Player->pev->punchangle.Length2D(),
+                    (Player->pev->punchangle.Length2D() <= this->m_MaxPunchAngle->value) ? "Yes" : "No"
+                );
+            }
+            
+            if (Player->pev->punchangle.Length2D() > this->m_MaxPunchAngle->value)
+            {
+                return vecSpread;
+            }
+        }
+    }
+
+    // Check Blocked Weapons
+    if (this->m_Weapons)
+    {
+        if (this->m_Weapons->string[0u] != '\0')
+        {
+            // m_pActiveItem null check added before dereferencing m_iId.
+            // In the original code, if m_pActiveItem is null (player just switched
+            // weapon, or weapon was force-removed by another plugin such as rezombie),
+            // m_pActiveItem->m_iId is a null-pointer dereference -> SIGSEGV.
+            if (Player->m_pActiveItem)
+            {
+                if (Player->m_pActiveItem->m_iId >= WEAPON_P228 && Player->m_pActiveItem->m_iId <= WEAPON_P90)
+                {
+                    // bounds check on the string index BEFORE indexing.
+                    // The original code used m_iId (up to 30) as a direct char array
+                    // index with no length guard. If sc_weapons_block is set to a
+                    // string shorter than 30 chars (e.g. the user provides a partial
+                    // string), this reads beyond the string buffer -> UB / garbage value.
+                    int weaponId = Player->m_pActiveItem->m_iId;
+                    size_t blockStrLen = strlen(this->m_Weapons->string);
+
+                    if ((size_t)weaponId < blockStrLen)
                     {
                         if (DebugMode)
                         {
@@ -148,123 +279,39 @@ float CSpread::GetSpread(CBaseEntity *pEntity, Vector &vecSrc, Vector &vecDirSho
                             (
                                 Player->edict(),
                                 E_PRINT::CHAT,
-                                "[%s] Ground Check: %2.2f (OnGround: %s) (Pass: %s)",
+                                "[%s] Weapon Position: %d (Is Blocked: %s)",
                                 Plugin_info.logtag,
-                                this->m_GroundCheck->value,
-                                (Player->pev->flags & FL_ONGROUND) ? "Yes" : "No",
-                                (Player->pev->flags & FL_ONGROUND) ? "Yes" : "No"
-                            );
-                        }
-
-                        if (!(Player->pev->flags & FL_ONGROUND))
-                        {
-                            return vecSpread;
-                        }
-                    }
-                }
-
-                // If player is moving: Block if player speed is greater than: (weapon-max-speed / max-speed-cvar-value)
-                if (this->m_MaxSpeed)
-                {
-                    if (this->m_MaxSpeed->value > 0.0f)
-                    {
-                        if (Player->pev->maxspeed > 0.0f)
-                        {
-                            if (DebugMode)
-                            {
-                                this->ClientPrint
-                                (
-                                    Player->edict(),
-                                    E_PRINT::CHAT,
-                                    "[%s] Max Speed Divisor: %2.2f (Player Velocity: %2.2f) (MaxSpeed: %2.2f) (Pass: %s)",
-                                    Plugin_info.logtag,
-                                    this->m_MaxSpeed->value,
-                                    Player->pev->velocity.Length2D(),
-                                    Player->pev->maxspeed,
-                                    (Player->pev->velocity.Length2D() <= (Player->pev->maxspeed / this->m_MaxSpeed->value)) ? "Yes" : "No"
-                                );
-                            }
-
-                            if (Player->pev->velocity.Length2D() > (Player->pev->maxspeed / this->m_MaxSpeed->value))
-                            {
-                                return vecSpread;
-                            }
-                        }
-                    }
-                }
-
-                // If player has fired: Do not remove spread if player is shoting a lot
-                if (this->m_MaxPunchAngle)
-                {
-                    if (this->m_MaxPunchAngle->value >= 0.0f)
-                    {
-                        if (DebugMode)
-                        {
-                            this->ClientPrint
-                            (
-                                Player->edict(),
-                                E_PRINT::CHAT,
-                                "[%s] Max Punch Angle: %2.2f (Player Punch Angle: %2.2f) (Pass: %s)",
-                                Plugin_info.logtag,
-                                this->m_MaxPunchAngle->value,
-                                Player->pev->punchangle.Length2D(),
-                                (Player->pev->punchangle.Length2D() <= this->m_MaxPunchAngle->value) ? "Yes" : "No"
+                                weaponId,
+                                (this->m_Weapons->string[weaponId] != '0') ? "Yes" : "No"
                             );
                         }
                         
-                        if (Player->pev->punchangle.Length2D() > this->m_MaxPunchAngle->value)
+                        if (this->m_Weapons->string[weaponId] != '0')
                         {
                             return vecSpread;
                         }
                     }
                 }
-
-                // Check Blocked Weapons
-                if (this->m_Weapons)
-                {
-                    if (this->m_Weapons->string[0u] != '\0')
-                    {
-                        if (Player->m_pActiveItem->m_iId >= WEAPON_P228 && Player->m_pActiveItem->m_iId <= WEAPON_P90)
-                        {
-                            if (DebugMode)
-                            {
-                                this->ClientPrint
-                                (
-                                    Player->edict(),
-                                    E_PRINT::CHAT,
-                                    "[%s] Weapon Position: %d (Is Blocked: %s)",
-                                    Plugin_info.logtag,
-                                    Player->m_pActiveItem->m_iId,
-                                    (this->m_Weapons->string[Player->m_pActiveItem->m_iId] != '0') ? "Yes" : "No"
-                                );
-                            }
-                            
-                            if (this->m_Weapons->string[Player->m_pActiveItem->m_iId] != '0')
-                            {
-                                return vecSpread;
-                            }
-                        }
-                    }
-                }
-
-                // Do not remove spred if player is not aimming his weapons like AWP, SCOUT or other
-                if (!Player->m_bResumeZoom)
-                {
-                    if (Player->m_pActiveItem->m_iId == WEAPON_SCOUT || Player->m_pActiveItem->m_iId == WEAPON_SG550 || Player->m_pActiveItem->m_iId == WEAPON_AWP || Player->m_pActiveItem->m_iId == WEAPON_G3SG1)
-                    {
-                        return vecSpread;
-                    }
-                }
-
-                // Spread value to return
-                if (this->m_Spread)
-                {
-                    if (this->m_Spread->value >= 0.0f)
-                    {
-                        return this->m_Spread->value;
-                    }
-                }
             }
+        }
+    }
+
+    // Do not remove spread if player is not aiming his weapons like AWP, SCOUT or other
+    // m_pActiveItem null check before dereferencing m_iId (same pattern as above).
+    if (!Player->m_bResumeZoom && Player->m_pActiveItem)
+    {
+        if (Player->m_pActiveItem->m_iId == WEAPON_SCOUT || Player->m_pActiveItem->m_iId == WEAPON_SG550 || Player->m_pActiveItem->m_iId == WEAPON_AWP || Player->m_pActiveItem->m_iId == WEAPON_G3SG1)
+        {
+            return vecSpread;
+        }
+    }
+
+    // Spread value to return
+    if (this->m_Spread)
+    {
+        if (this->m_Spread->value >= 0.0f)
+        {
+            return this->m_Spread->value;
         }
     }
 

--- a/spread/Spread.h
+++ b/spread/Spread.h
@@ -16,13 +16,14 @@ public:
     float GetSpread(CBaseEntity *pEntity, Vector &vecSrc, Vector &vecDirShooting, float vecSpread, float flDistance, int iPenetration, int iBulletType, int iDamage, float flRangeModifier, entvars_t *pevAttacker, bool bPistol, int shared_rand);
     void ClientPrint(edict_t *pEntity, int iMsgDest, const char *Format, ...);
 
-    cvar_t* m_Debug = nullptr;
-    cvar_t* m_Active = nullptr;
-    cvar_t* m_GroundCheck = nullptr;
-    cvar_t* m_MaxSpeed = nullptr;
+    cvar_t* m_Debug         = nullptr;
+    cvar_t* m_Active        = nullptr;
+    cvar_t* m_GroundCheck   = nullptr;
+    cvar_t* m_MaxSpeed      = nullptr;
     cvar_t* m_MaxPunchAngle = nullptr;
-    cvar_t* m_Spread = nullptr;
-    cvar_t* m_Weapons;
+    cvar_t* m_Spread        = nullptr;
+    cvar_t* m_Weapons       = nullptr;  // was missing = nullptr — uninitialized pointer
+                                        //      could cause UB on any read before ServerActivate()
 };
 
 extern CSpread gSpread;


### PR DESCRIPTION
### 📄 Description

This PR fixes multiple **critical validation issues** in `Spread.cpp` and `Spread.h` that were causing **SIGSEGV crashes**, undefined behavior, and incompatibilities with other modules (notably `rezombie` and entities like `func_tank`).

The main problem was unsafe assumptions about entity validity and type, especially during `FireBullets3` execution.

---

### 🔍 Root Cause

The crashes were primarily caused by:

* Casting invalid or non-player entities to `CBasePlayer*`
* Accessing freed or invalid edicts
* Missing null checks on weapon pointers
* Out-of-bounds access in weapon configuration
* Lack of proper entity index validation

This becomes critical when other modules (e.g. `rezombie`) trigger `FireBullets3` using **non-player entities**, leading to invalid memory access.

---

### ✅ Fixes Applied

#### 1. Early return for inactive state

* Moved `m_Active` check to the top of `GetSpread()`
* Prevents unnecessary execution when disabled
  ✔ Improves safety and efficiency

---

#### 2. Safe entity validation before casting

* Added validation for `pEntity` before casting to `CBasePlayer*`
* Prevents casting invalid pointers
  🔴 Fixes primary crash source

---

#### 3. Edict validity check

* Added check for `edict()->free`
* Handles cases where entity was removed in the same frame (disconnect, respawn, etc.)
  🔴 Prevents use-after-free crashes

---

#### 4. Entity index range validation (**critical fix**)

* Ensures entity index is within `[1..maxClients]`
* Prevents treating non-player entities as players

🔴 **This directly fixes the crash seen in the backtrace**

---

#### 5. Null check for active weapon

* Added validation for `m_pActiveItem` before accessing it
  🔴 Prevents SIGSEGV when weapon is removed mid-frame

---

#### 6. Safe access to weapon configuration

* Added bounds/length validation before accessing `m_Weapons->string[m_iId]`
  🟠 Prevents out-of-bounds reads / undefined behavior

---

#### 7. Zoom state validation

* Added null check for `m_pActiveItem` before using `m_iId` in zoom logic
  🔴 Prevents additional crash scenario

---

#### 8. Proper initialization

* Initialized `cvar_t* m_Weapons = nullptr`
  🟠 Prevents undefined behavior before `ServerActivate()`

---

### 🎯 Impact

* Fixes **random SIGSEGV crashes during weapon firing**
* Improves compatibility with:

  * ReAPI
  * rezombie
  * custom entities (e.g. `func_tank`)
* Makes the module **safe under high plugin interaction scenarios**

---

### 🧠 Important Note

The most critical fix is **entity index validation ([1..maxClients])**:

> Some modules (like `rezombie`) trigger `FireBullets3` from non-player entities.
> Without validation, the code casts these entities to `CBasePlayer*`, causing invalid memory access when reading fields like `pev->flags`, `pev->maxspeed`, or `m_pActiveItem`.

---

### 🚀 Result

The module is now:

* Crash-safe
* Defensive against invalid entities
* Compatible with modern ReHLDS + ReAPI setups

---
